### PR TITLE
Small optimizations, doc&README cleanup and release v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,13 @@ cache: cargo
 matrix:
   include:
     - rust: stable
+      env: BENCHES=false
     - rust: beta
+      env: BENCHES=false
     - rust: nightly
       env: BENCHES=true
     - rust: 1.22.0
+      env: BENCHES=false
 
 before_install:
   - sudo apt-get -qq update

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,5 +41,7 @@ bitcoin_hashes = "0.7.6"
 unicode-normalization = "=0.1.9"
 rand = { version = "0.6.0", optional = true }
 
+serde = { version = "1.0", optional = true }
+
 [dev-dependencies]
 rand = { version = "0.6.0", optional = false }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,30 @@
 bip39
 =====
 
-A Rust implementation of BIP-39 mnemonic codes.
+A Rust implementation of [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
+mnemonic codes.
+
+
+## Word lists (languages)
+
+We support all languages
+[specified in the BIP-39 standard](https://github.com/bitcoin/bips/blob/master/bip-0039/bip-0039-wordlists.md)
+as of writing.
+
+The English language is always loaded and other languages can be loaded using the corresponding feature.
+
+Use the `all-languages` feature to enable all languages.
+
+- English (always enabled)
+- Simplified Chinese (`chinese-simplified`)
+- Traditional Chinese (`chinese-traditional`)
+- Czech (`czech`)
+- French (`french`)
+- Italian (`italian`)
+- Japanese (`japanese`)
+- Korean (`korean`)
+- Spanish (`spanish`)
+
 
 ## MSRV
 

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -1,0 +1,59 @@
+
+/// Implement serde serialization based on the 
+/// fmt::Display and std::FromStr traits.
+macro_rules! serde_string_impl {
+    ($name:ident, $expecting:expr) => {
+        #[cfg(feature = "serde")]
+        impl<'de> $crate::serde::Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<$name, D::Error>
+            where
+                D: $crate::serde::de::Deserializer<'de>,
+            {
+                use ::std::fmt::{self, Formatter};
+                use ::std::str::FromStr;
+
+                struct Visitor;
+                impl<'de> $crate::serde::de::Visitor<'de> for Visitor {
+                    type Value = $name;
+
+                    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                        formatter.write_str($expecting)
+                    }
+
+                    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                    where
+                        E: $crate::serde::de::Error,
+                    {
+                        $name::from_str(v).map_err(E::custom)
+                    }
+
+                    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+                    where
+                        E: $crate::serde::de::Error,
+                    {
+                        self.visit_str(v)
+                    }
+
+                    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+                    where
+                        E: $crate::serde::de::Error,
+                    {
+                        self.visit_str(&v)
+                    }
+                }
+
+                deserializer.deserialize_str(Visitor)
+            }
+        }
+
+        #[cfg(feature = "serde")]
+        impl<'de> $crate::serde::Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: $crate::serde::Serializer,
+            {
+                serializer.collect_str(&self)
+            }
+        }
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use language::Language;
 
 
 /// A BIP39 error.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
 	/// Mnemonic has a word count that is not a multiple of 6.
 	BadWordCount(usize),
@@ -74,11 +74,6 @@ impl fmt::Display for Error {
 			Error::InvalidChecksum => write!(f, "the mnemonic has an invalid checksum"),
 			Error::AmbiguousWordList(ref langs) => write!(f, "ambiguous word list: {:?}", langs),
 		}
-	}
-}
-impl fmt::Debug for Error {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		fmt::Display::fmt(self, f)
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@ mod pbkdf2;
 
 pub use language::Language;
 
+/// The maximum number of words in a mnemonic.
+const MAX_NB_WORDS: usize = 24;
 
 /// A BIP39 error.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -156,7 +158,7 @@ impl Mnemonic {
 	/// For the different supported word counts, see documentation on [Mnemonoc].
 	#[cfg(feature = "rand")]
 	pub fn generate_in(language: Language, word_count: usize) -> Result<Mnemonic, Error> {
-		if word_count < 6 || word_count % 6 != 0 || word_count > 24 {
+		if word_count < 6 || word_count % 6 != 0 || word_count > MAX_NB_WORDS {
 			return Err(Error::BadWordCount(word_count));
 		}
 
@@ -177,7 +179,7 @@ impl Mnemonic {
 	/// Static method to validate a mnemonic in a given language.
 	pub fn validate_in(language: Language, s: &str) -> Result<(), Error> {
 		let words: Vec<&str> = s.split_whitespace().collect();
-		if words.len() < 6 || words.len() % 6 != 0 || words.len() > 24 {
+		if words.len() < 6 || words.len() % 6 != 0 || words.len() > MAX_NB_WORDS {
 			return Err(Error::BadWordCount(words.len()));
 		}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,19 +260,19 @@ impl Mnemonic {
 		Err(Error::AmbiguousWordList(langs))
 	}
 
+	/// Parse a mnemonic in the given language.
+	pub fn parse_in<'a, S: Into<Cow<'a, str>>>(language: Language, s: S) -> Result<Mnemonic, Error> {
+		let mut cow = s.into();
+		Mnemonic::normalize_utf8_cow(&mut cow);
+		Mnemonic::validate_in(language, cow.as_ref())?;
+		Ok(Mnemonic(cow.into_owned()))
+	}
+
 	/// Parse a mnemonic and detect the language from the enabled languages.
 	pub fn parse<'a, S: Into<Cow<'a, str>>>(s: S) -> Result<Mnemonic, Error> {
 		let mut cow = s.into();
 		Mnemonic::normalize_utf8_cow(&mut cow);
 		let language = Mnemonic::language_of(cow.as_ref())?;
-		Mnemonic::validate_in(language, cow.as_ref())?;
-		Ok(Mnemonic(cow.into_owned()))
-	}
-
-	/// Parse a mnemonic in the given language.
-	pub fn parse_in<'a, S: Into<Cow<'a, str>>>(language: Language, s: S) -> Result<Mnemonic, Error> {
-		let mut cow = s.into();
-		Mnemonic::normalize_utf8_cow(&mut cow);
 		Mnemonic::validate_in(language, cow.as_ref())?;
 		Ok(Mnemonic(cow.into_owned()))
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,7 +306,7 @@ impl Mnemonic {
 	}
 
 	/// Convert to seed bytes.
-	pub fn to_seed(&self, passphrase: &str) -> Vec<u8> {
+	pub fn to_seed(&self, passphrase: &str) -> [u8; 64] {
 		const PBKDF2_ROUNDS: usize = 2048;
 		const PBKDF2_BYTES: usize = 64;
 
@@ -320,7 +320,7 @@ impl Mnemonic {
 			Mnemonic::normalize_utf8_cow(&mut cow);
 			cow
 		};
-		let mut seed = vec![0u8; PBKDF2_BYTES];
+		let mut seed = [0u8; PBKDF2_BYTES];
 		pbkdf2::pbkdf2(
 			&normalized_mnemonic_cow.as_ref().as_bytes(),
 			&normalized_salt_cow.as_ref().as_bytes(),
@@ -546,7 +546,7 @@ mod tests {
 				"failed vector: {}", mnemonic_str);
 			assert_eq!(&entropy, &mnemonic.to_entropy(),
 				"failed vector: {}", mnemonic_str);
-			assert_eq!(&seed, &mnemonic.to_seed("TREZOR"),
+			assert_eq!(&seed[..], &mnemonic.to_seed("TREZOR")[..],
 				"failed vector: {}", mnemonic_str);
 		}
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,11 @@
 
 extern crate bitcoin_hashes;
 extern crate unicode_normalization;
+
 #[cfg(feature = "rand")]
 extern crate rand;
+#[cfg(feature = "serde")]
+pub extern crate serde;
 
 use std::{error, fmt, str};
 use std::borrow::Cow;
@@ -37,6 +40,8 @@ use std::borrow::Cow;
 use bitcoin_hashes::{sha256, Hash};
 use unicode_normalization::UnicodeNormalization;
 
+#[macro_use]
+mod internal_macros;
 mod language;
 mod pbkdf2;
 
@@ -99,6 +104,8 @@ impl error::Error for Error {
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Mnemonic(String);
 // The content of the mnemonic is ensured to be NFKD-normalized UTF-8.
+
+serde_string_impl!(Mnemonic, "a BIP-39 Mnemonic Code");
 
 impl Mnemonic {
 	/// Ensure the content of the [Cow] is normalized UTF8.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,10 +42,6 @@ mod pbkdf2;
 
 pub use language::Language;
 
-/// The ideagrapic space that should be used for Japanese lists.
-#[cfg(feature = "japanese")]
-#[allow(unused)]
-const IDEOGRAPHIC_SPACE: char = '　';
 
 /// A BIP39 error.
 #[derive(Clone, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,13 +148,13 @@ impl Mnemonic {
 		Ok(Mnemonic(words.join(" ")))
 	}
 
-	/// Create a new English [Mnemonic] in from the given entropy.
+	/// Create a new English [Mnemonic] from the given entropy.
 	/// Entropy must be a multiple of 32 bits (4 bytes) and 128-256 bits in length.
 	pub fn from_entropy(entropy: &[u8]) -> Result<Mnemonic, Error> {
 		Mnemonic::from_entropy_in(Language::English, entropy)
 	}
 
-	/// Generate a new Mnemonic in the given language.
+	/// Generate a new [Mnemonic] in the given language.
 	/// For the different supported word counts, see documentation on [Mnemonoc].
 	#[cfg(feature = "rand")]
 	pub fn generate_in(language: Language, word_count: usize) -> Result<Mnemonic, Error> {
@@ -169,7 +169,7 @@ impl Mnemonic {
 		Mnemonic::from_entropy_in(language, &entropy)
 	}
 
-	/// Generate a new Mnemonic in English.
+	/// Generate a new [Mnemonic] in English.
 	/// For the different supported word counts, see documentation on [Mnemonoc].
 	#[cfg(feature = "rand")]
 	pub fn generate(word_count: usize) -> Result<Mnemonic, Error> {


### PR DESCRIPTION
There is a single small API change: the `Mnemonic::to_seed` method is changes from returning a `Vec<u8>` that is always 64 bytes long to returning a `[u8; 64]` instead.

Some optimizations are made to avoid some unnecessary allocations. The only methods that still make allocations are `Mnemonic::language_of` (to determine which language is a mnemonic) and `Mnemonic::to_entropy` (to reverse a mnemonic back into its entropy). Both these methods are not used when just using English mnemonics.