### PR TITLE
Use indices internally instead of &'static str + language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+# v1.0.1
+
+- Add `Mnemonic::language` getter.
+- Make `Mnemonic::language_of` static method public.
+- Change internal representation of `Mnemonic`, making it slightly smaller.
 
 # v1.0.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip39"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Steven Roose <steven@stevenroose.org>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-bip39/"

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -146,8 +146,8 @@ impl Language {
 
 	/// Get the index of the word in the word list.
 	#[inline]
-	pub(crate) fn find_word(self, word: &str) -> Option<usize> {
-		self.word_list().iter().position(|w| *w == word)
+	pub(crate) fn find_word(self, word: &str) -> Option<u16> {
+		self.word_list().iter().position(|w| *w == word).map(|i| i as u16)
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,7 +370,7 @@ impl Mnemonic {
 	/// word lists. In the extremely unlikely case that a word list can be
 	/// interpreted in multiple languages, an [Error::AmbiguousLanguages] is
 	/// returned, containing the possible languages.
-	fn language_of<S: AsRef<str>>(mnemonic: S) -> Result<Language, Error> {
+	pub fn language_of<S: AsRef<str>>(mnemonic: S) -> Result<Language, Error> {
 		Mnemonic::language_of_iter(mnemonic.as_ref().split_whitespace())
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,6 +294,11 @@ impl Mnemonic {
 		Mnemonic::generate_in(Language::English, word_count)
 	}
 
+	/// Get the language of the [Mnemonic].
+	pub fn language(&self) -> Language {
+		self.lang
+	}
+
 	/// Get an iterator over the words.
 	pub fn word_iter(&self) -> impl Iterator<Item = &'static str> + Clone + '_ {
 		let list = self.lang.word_list();


### PR DESCRIPTION
This change should not break any API, it only adds an extra `Clone` on the `word_iter` method.