### PR TITLE
Add no-std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ path = "src/lib.rs"
 
 [features]
 default = [ "std" ]
-std = [ "unicode-normalization", "serde/std" ]
+std = [ "unicode-normalization", "serde/std", "bitcoin_hashes/std" ]
+no-std = [ "bitcoin_hashes/alloc" ]
 
 # Note: English is the standard for bip39 so always included
 chinese-simplified = []
@@ -40,7 +41,7 @@ all-languages = [
 ]
 
 [dependencies]
-bitcoin_hashes = "0.9.4"
+bitcoin_hashes = { version = "0.9.4", default-features = false }
 rand_core = "0.4.0"
 
 unicode-normalization = { version = "=0.1.9", optional = true }


### PR DESCRIPTION
This feature allows to use rust-bip39 in no-std scenarios. It wouldn't
work before, as `bitcoin_hashes` was imported with std support.

If you try to include `bip39` without the new `no-std` feature, like this:
```
bip39 = { version = "1.0", default-features = false }
```
compiling gives you:
```
❯ cargo build
    Updating crates.io index
   Compiling bitcoin_hashes v0.9.7
error[E0463]: can't find crate for `std`
  |
  = note: the `thumbv7em-none-eabihf` target may not support the standard library
  = note: `std` is required by `bitcoin_hashes` because it does not declare `#![no_std]`

For more information about this error, try `rustc --explain E0463`.
error: could not compile `bitcoin_hashes` due to previous error
```