### PR TITLE
Make word list public; addresses #19

### DIFF
--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -82,7 +82,7 @@ impl Language {
 
 	/// The word list for this language.
 	#[inline]
-	pub(crate) fn word_list(self) -> &'static [&'static str; 2048] {
+	pub fn word_list(self) -> &'static [&'static str; 2048] {
 		match self {
 			Language::English => &english::WORDS,
 			#[cfg(feature = "chinese-simplified")]
@@ -146,7 +146,7 @@ impl Language {
 
 	/// Get the index of the word in the word list.
 	#[inline]
-	pub(crate) fn find_word(self, word: &str) -> Option<u16> {
+	pub fn find_word(self, word: &str) -> Option<u16> {
 		self.word_list().iter().position(|w| *w == word).map(|i| i as u16)
 	}
 }


### PR DESCRIPTION
There are many use cases to make word list public as seen in issue #19 ; this will expand the applicability of rust-bip39 library.