### PR TITLE
Remove "We currently don't implement seed generation from the phrase."

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@
 
 //! # BIP39 Mnemonic Codes
 //!
-//! We currently don't implement seed generation from the phrase.
-//!
 //! https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
 //!
 


### PR DESCRIPTION
This shows up prominently at https://docs.rs/bip39/1.0.1/bip39/index.html , but it appears that seed generation is indeed implemented in the `to_seed()` method.