### PR TITLE
Enable edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,6 @@ keywords = [ "crypto", "bitcoin", "bip39", "mnemonic" ]
 readme = "README.md"
 edition = "2018"
 
-[lib]
-name = "bip39"
-path = "src/lib.rs"
-
 [features]
 default = [ "std" ]
 std = [ "unicode-normalization", "serde/std" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/bip39/"
 description = "Library for BIP-39 Bitcoin mnemonic codes"
 keywords = [ "crypto", "bitcoin", "bip39", "mnemonic" ]
 readme = "README.md"
+edition = "2018"
 
 [lib]
 name = "bip39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,12 +38,12 @@ all-languages = [
 
 [dependencies]
 bitcoin_hashes = "0.9.4"
-rand_core = "0.4.0"
+rand_core = "0.6.3"
 
 unicode-normalization = { version = "=0.1.9", optional = true }
-rand = { version = "0.6.0", optional = true }
+rand = { version = "0.8.5", optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 zeroize = {version = "1.5", features = ["zeroize_derive"], optional = true}
 
 [dev-dependencies]
-rand = { version = "0.6.0", optional = false }
+rand = { version = "0.8.5", optional = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,4 +50,3 @@ zeroize = {version = "1.5", features = ["zeroize_derive"], optional = true}
 
 [dev-dependencies]
 rand = { version = "0.6.0", optional = false }
-

--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ Use the `all-languages` feature to enable all languages.
 
 ## MSRV
 
-This crate supports Rust v1.29 and up and works with `no_std`.
+This crate supports Rust v1.41.1 and up and works with `no_std`.
 


### PR DESCRIPTION
Bump the MSRV to 1.41.1 and enable edition 2018. This is the same as what we have been doing across the rust-bitcoin stack.