### PR TITLE
Unpin `unicode-normalization` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ all-languages = [
 bitcoin_hashes = "0.9.4"
 rand_core = "0.4.0"
 
-unicode-normalization = { version = "=0.1.9", optional = true }
+unicode-normalization = { version = "0.1.9", optional = true }
 rand = { version = "0.6.0", optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 zeroize = {version = "1.5", features = ["zeroize_derive"], optional = true}


### PR DESCRIPTION
I ran into an issue where the very old pinned version of `unicode-normalization` conflicted with another dependency:

```
error: failed to select a version for `unicode-normalization`.
    ... required by package `idna v0.2.3`
    ... which satisfies dependency `idna = "^0.2.3"` of package `cookie_store v0.16.0`
    ... which satisfies dependency `cookie_store = "^0.16"` of package `reqwest v0.11.11`
    ... which satisfies dependency `reqwest = "^0.11.11"` of package `turbo v0.1.0 (/Users/e/Documents/GitHub/turbo)`
versions that meet the requirements `^0.1.17` are: 0.1.21, 0.1.20, 0.1.19, 0.1.18, 0.1.17

all possible versions conflict with previously selected packages.

  previously selected package `unicode-normalization v0.1.9`
    ... which satisfies dependency `unicode-normalization = "=0.1.9"` of package `bip39 v1.0.0`
    ... which satisfies dependency `bip39 = "^1"` of package `turbo v0.1.0 (/Users/e/Documents/GitHub/turbo)`

failed to select a version for `unicode-normalization` which could resolve this conflict
```

Removing this pin resolved it, and I couldn't find a reason why it was pinned. `cargo test` passes.

Closes #29