### PR TITLE
Add changelog and bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+# v1.1.0
+
+- Add optional [zeroize](https://docs.rs/zeroize/latest/zeroize/) support
+- Allow word count multiples of three (previously was six)
+- Make word list public
+
 # v1.0.1
 
 - Add `Mnemonic::language` getter.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip39"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Steven Roose <steven@stevenroose.org>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-bip39/"


### PR DESCRIPTION
We have added to the public API since last release so the next version number should be a minor version number bump.

Add an entry to the CHANGELOG and bump the version to the next minor release version number 1.1.0