### PR TITLE
Add rust ci workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,84 @@
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+  Tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+          - stable
+          - beta
+          - 1.29.0
+        features:
+          - default
+          - all-languages
+          - default,rand,all-languages
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Building
+        run: cargo build --features ${{ matrix.features }} --no-default-features
+      - name: Running tests
+        run: cargo test --features ${{ matrix.features }} --no-default-features
+
+  Benches:
+    name: Benches
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+          - rand
+          - rand,japanese
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - name: Running benches
+        run: cargo bench --features ${{ matrix.features }}
+
+  Clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: clippy
+      - name: Running clippy
+        run: cargo clippy --all-features -- -Dwarnings -Aclippy::needless_range_loop -Aclippy::ptr_arg -Aclippy::manual-range-contains
+
+  Format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt
+      - name: Checking format
+        run: cargo fmt --all -- --config format_code_in_doc_comments=true --check

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,5 @@
 hard_tabs = true
 use_small_heuristics = "Off"
+ignore = [
+    "src/language",
+]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -56,6 +56,7 @@ fn from_entropy(b: &mut Bencher) {
 	});
 }
 
+#[cfg(feature = "rand")]
 #[bench]
 fn new_mnemonic(b: &mut Bencher) {
 	b.iter(|| {

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -1,10 +1,11 @@
 use bitcoin_hashes::{hmac, sha512, Hash, HashEngine};
 
-const SALT_PREFIX: &'static str = "mnemonic";
+const SALT_PREFIX: &str = "mnemonic";
 
 /// Calculate the binary size of the mnemonic.
 fn mnemonic_byte_len<M>(mnemonic: M) -> usize
-	where M: Iterator<Item = &'static str> + Clone,
+where
+	M: Iterator<Item = &'static str> + Clone,
 {
 	let mut len = 0;
 	for (i, word) in mnemonic.enumerate() {
@@ -18,7 +19,8 @@ fn mnemonic_byte_len<M>(mnemonic: M) -> usize
 
 /// Wrote the mnemonic in binary form into the hash engine.
 fn mnemonic_write_into<M>(mnemonic: M, engine: &mut sha512::HashEngine)
-	where M: Iterator<Item = &'static str> + Clone,
+where
+	M: Iterator<Item = &'static str> + Clone,
 {
 	for (i, word) in mnemonic.enumerate() {
 		if i > 0 {
@@ -32,7 +34,8 @@ fn mnemonic_write_into<M>(mnemonic: M, engine: &mut sha512::HashEngine)
 /// We need a special method because we can't allocate a new byte
 /// vector for the entire serialized mnemonic.
 fn create_hmac_engine<M>(mnemonic: M) -> hmac::HmacEngine<sha512::Hash>
-	where M: Iterator<Item = &'static str> + Clone,
+where
+	M: Iterator<Item = &'static str> + Clone,
 {
 	// Inner code is borrowed from the bitcoin_hashes::hmac::HmacEngine::new method.
 	let mut ipad = [0x36u8; 128];
@@ -58,8 +61,8 @@ fn create_hmac_engine<M>(mnemonic: M) -> hmac::HmacEngine<sha512::Hash>
 		let mut cursor = 0;
 		for (i, word) in mnemonic.enumerate() {
 			if i > 0 {
-				ipad[cursor] ^= ' ' as u8;
-				opad[cursor] ^= ' ' as u8;
+				ipad[cursor] ^= b' ';
+				opad[cursor] ^= b' ';
 				cursor += 1;
 			}
 			for (b_i, b_h) in ipad.iter_mut().skip(cursor).zip(word.as_bytes()) {
@@ -83,7 +86,7 @@ fn create_hmac_engine<M>(mnemonic: M) -> hmac::HmacEngine<sha512::Hash>
 fn u32_to_array_be(val: u32) -> [u8; 4] {
 	let mut res = [0; 4];
 	for i in 0..4 {
-		res[i] = ((val >> (4 - i - 1) * 8) & 0xff) as u8;
+		res[i] = ((val >> ((4 - i - 1) * 8)) & 0xff) as u8;
 	}
 	res
 }
@@ -97,7 +100,8 @@ fn xor(res: &mut [u8], salt: &[u8]) {
 
 /// PBKDF2-HMAC-SHA512 implementation using bitcoin_hashes.
 pub(crate) fn pbkdf2<M>(mnemonic: M, unprefixed_salt: &[u8], c: usize, res: &mut [u8])
-	where M: Iterator<Item = &'static str> + Clone,
+where
+	M: Iterator<Item = &'static str> + Clone,
 {
 	let prf = create_hmac_engine(mnemonic);
 


### PR DESCRIPTION
This adds a basic rust ci workflow following what I found in `.travis.yml` to run fmt, clippy and tests with different versions of rust and different features.

I allow the below clippy checks in the workflow command so everything passes with rust 1.29:
```
clippy:needless_range_loop
clippy::ptr_arg 
clippy::manual-range-contains
```