### PR TITLE
Document the MSRV when zeroize feature is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ rand_core = "0.4.0"
 unicode-normalization = { version = "=0.1.9", optional = true }
 rand = { version = "0.6.0", optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
+# Enabling this feature raises the MSRV to 1.51
 zeroize = {version = "1.5", features = ["zeroize_derive"], optional = true}
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ Use the `all-languages` feature to enable all languages.
 
 This crate supports Rust v1.29 and up and works with `no_std`.
 
+If you enable the `zeroize` feature the MSRV becomes 1.51


### PR DESCRIPTION
Enabling the `zeroize` raises the MSRV to 1.51

Add documentation to the README and also to the manifest.