### PR TITLE
Bump `rand` related crates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,13 +41,13 @@ all-languages = [
 
 [dependencies]
 bitcoin_hashes = "0.9.4"
-rand_core = "0.4.0"
+rand_core = "0.6.4"
 
 unicode-normalization = { version = "=0.1.9", optional = true }
-rand = { version = "0.6.0", optional = true }
+rand = { version = "0.8.5", optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 zeroize = {version = "1.5", features = ["zeroize_derive"], optional = true}
 
 [dev-dependencies]
-rand = { version = "0.6.0", optional = false }
+rand = { version = "0.8.5", optional = false }
 


### PR DESCRIPTION
rand_core to 0.6.4
rand to 0.8.5

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

This will enable us to create mnemonics on wasm32.
I checked on the latest version of Chrome.

```
// Example: Part-of-core.rs
let m = Mnemonic::generate_in(Language::English, 12).unwrap();
```

```
// Example: Part-of-Cargo.toml
[patch.crates-io]
bip39 = { git = "https://github.com/monaka/rust-bip39", branch = "bump-rand-and-rand_core" }

[dependencies]
bip39 = { version = "1.0.1", features = ["rand"] }
getrandom = { version = "0.2", features = ["js"] }
```
