### PR TITLE
Update CHANGELOG and bump to v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+# v1.1.0
+
+- Add zerioze support through a feature (MSRV 1.51)
+- Allow word count multiples of 3 instead of 6
+- Add support for no-std usage
+- Expose `Language::word_list` and `Language::find_word` methods
+
 # v1.0.1
 
 - Add `Mnemonic::language` getter.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip39"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Steven Roose <steven@stevenroose.org>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-bip39/"


### PR DESCRIPTION
Sorry @tcharding that this duplicates https://github.com/rust-bitcoin/rust-bip39/pull/32 for the most part. I added another item that I merged recently and I want to see what I can do with regards to MSRV without having to breaking change exposed deps.