### PR TITLE
Add CI by way of GitHub actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,124 @@
+
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+  Stable:
+    name: Test - stable toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        # https://github.com/dtolnay/rust-toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Running test script
+        env:
+          DO_FEATURE_MATRIX: true
+        run: ./contrib/test.sh
+
+  Beta:
+    name: Test - beta toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@beta
+      - name: Running test script
+        env:
+          DO_FEATURE_MATRIX: true
+        run: ./contrib/test.sh
+
+  Nightly:
+    name: Test - nightly toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Running test script
+        env:
+          DO_BENCH: true
+        run: ./contrib/test.sh
+
+  MSRV:
+    name: Test - 1.29 toolchain
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@1.29
+      - name: Running test script
+        env:
+          DO_FEATURE_MATRIX: true
+        run: ./contrib/test.sh
+
+  Arch32bit:
+    name: Testing 32-bit version
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        # https://github.com/dtolnay/rust-toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Add architecture i386
+        run: sudo dpkg --add-architecture i386
+      - name: Install i686 gcc
+        run: sudo apt-get update -y && sudo apt-get install -y gcc-multilib
+      - name: Install target
+        run: rustup target add i686-unknown-linux-gnu
+      - name: Run test on i686
+        run: cargo test --target i686-unknown-linux-gnu
+
+  Cross:
+    name: Cross test
+    if: ${{ !github.event.act }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v3
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install target
+        run: rustup target add s390x-unknown-linux-gnu
+      - name: install cross
+        run: cargo install cross
+      - name: run cross test
+        run: cross test --target s390x-unknown-linux-gnu
+
+  Embedded:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-C link-arg=-Tlink.x"
+      CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER: "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        run: sudo apt update && sudo apt install -y qemu-system-arm gcc-arm-none-eabi
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: thumbv7m-none-eabi
+      - name: Install src
+        run: rustup component add rust-src
+      - name: Run
+        env:
+          RUSTFLAGS: "-C link-arg=-Tlink.x"
+          CARGO_TARGET_THUMBV7M_NONE_EABI_RUNNER: "qemu-system-arm -cpu cortex-m3 -machine mps2-an385 -nographic -semihosting-config enable=on,target=native -kernel"
+        run: cd embedded && cargo run --target thumbv7m-none-eabi

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -ex
+
+FEATURES="std unicode-normalization rand serde zeroize"
+LANGUAGES="chinese-simplified chinese-traditional czech french italian japanese korean spanish"
+
+cargo --version
+rustc --version
+
+# Defaults / sanity checks
+cargo build
+cargo test
+
+# Test each feature
+if [ "$DO_FEATURE_MATRIX" = true ]; then
+    cargo build --no-default-features
+    cargo test --no-default-features
+
+    # All features
+    cargo build --no-default-features --features="$FEATURES"
+    cargo test --no-default-features --features="$FEATURES"
+
+    # Single features
+    for feature in ${FEATURES}
+    do
+        cargo build --no-default-features --features="$feature"
+        cargo test --no-default-features --features="$feature"
+		# All combos of two features
+		for featuretwo in ${FEATURES}; do
+			cargo build --no-default-features --features="$feature $featuretwo"
+			cargo test --no-default-features --features="$feature $featuretwo"
+		done
+    done
+fi
+
+# Test each language with std
+for language in ${LANGUAGES}
+do
+    cargo test --verbose --features="$language"
+done
+
+# Bench if told to, must be run with non-stable (nightly, beta) toolchain.
+if [ "$DO_BENCH" = true ]; then
+    cargo bench
+fi


### PR DESCRIPTION
Add a github actions workflow, use dtolnay runner. Add a CI script and run it from the actions. Test for toolchains: stable, beta, nighttly, MSRV.

Based on the way we do it in other `rust-bitcoin` crates.

Note, please:

- Does not add clippy and does not do docs build.
- Uses MSRV 1.29
