### PR TITLE
Fix .editorconfig indent style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
 # see https://editorconfig.org for more options, and setup instructions for yours editor
 
 [*.rs]
-indent_style = tabs
+indent_style = tab


### PR DESCRIPTION
Minor fix because my editor was not using hard tabs.

Correct values are in singular, e.g: `space` and `tab`.