### PR TITLE
`alloc` feature added, to gate unicode normalization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ edition = "2018"
 
 [features]
 default = [ "std" ]
-std = [ "unicode-normalization", "serde/std" ]
+std = [ "alloc", "serde/std", "unicode-normalization/std" ]
 rand = [ "crate_rand", "rand_core" ]
+alloc = [ "unicode-normalization" ]
 
 # Note: English is the standard for bip39 so always included
 chinese-simplified = []
@@ -49,7 +50,7 @@ zeroize = { version = "1.5", features = ["zeroize_derive"], optional = true }
 
 # Unexported dependnecies
 bitcoin_hashes = { version = ">=0.12, <=0.13", default-features = false }
-unicode-normalization = { version = "=0.1.22", optional = true }
+unicode-normalization = { version = "=0.1.22", default-features = false, optional = true }
 
 [dev-dependencies]
 # Enabling the "rand" feature by default to run the benches

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,10 @@ extern crate bitcoin_hashes;
 #[cfg(feature = "std")]
 extern crate unicode_normalization;
 
-#[cfg(feature = "rand_core")]
-pub extern crate rand_core;
 #[cfg(feature = "rand")]
 pub extern crate crate_rand as rand;
+#[cfg(feature = "rand_core")]
+pub extern crate rand_core;
 #[cfg(feature = "serde")]
 pub extern crate serde;
 
@@ -542,12 +542,7 @@ impl Mnemonic {
 		const PBKDF2_BYTES: usize = 64;
 
 		let mut seed = [0u8; PBKDF2_BYTES];
-		pbkdf2::pbkdf2(
-			self.words(),
-			normalized_passphrase.as_bytes(),
-			PBKDF2_ROUNDS,
-			&mut seed,
-		);
+		pbkdf2::pbkdf2(self.words(), normalized_passphrase.as_bytes(), PBKDF2_ROUNDS, &mut seed);
 		seed
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,12 @@
 #[cfg(any(test, feature = "std"))]
 pub extern crate core;
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 extern crate bitcoin_hashes;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "unicode-normalization")]
 extern crate unicode_normalization;
 
 #[cfg(feature = "rand")]
@@ -43,16 +44,16 @@ pub extern crate rand_core;
 #[cfg(feature = "serde")]
 pub extern crate serde;
 
+#[cfg(feature = "alloc")]
+use alloc::{borrow::Cow, string::ToString, vec::Vec};
 use core::{fmt, str};
 
-#[cfg(feature = "std")]
-use std::borrow::Cow;
 #[cfg(feature = "std")]
 use std::error;
 
 use bitcoin_hashes::{sha256, Hash};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "unicode-normalization")]
 use unicode_normalization::UnicodeNormalization;
 
 #[cfg(feature = "zeroize")]
@@ -95,7 +96,7 @@ impl AmbiguousLanguages {
 	}
 
 	/// Returns a vector of the possible languages.
-	#[cfg(feature = "std")]
+	#[cfg(feature = "alloc")]
 	pub fn to_vec(&self) -> Vec<Language> {
 		self.iter().collect()
 	}
@@ -183,7 +184,7 @@ impl Mnemonic {
 	/// Performing this on a [Cow] means that all allocations for normalization
 	/// can be avoided for languages without special UTF8 characters.
 	#[inline]
-	#[cfg(feature = "std")]
+	#[cfg(feature = "unicode-normalization")]
 	pub fn normalize_utf8_cow<'a>(cow: &mut Cow<'a, str>) {
 		let is_nfkd = unicode_normalization::is_nfkd_quick(cow.as_ref().chars());
 		if is_nfkd != unicode_normalization::IsNormalized::Yes {
@@ -506,7 +507,7 @@ impl Mnemonic {
 	}
 
 	/// Parse a mnemonic in the given language.
-	#[cfg(feature = "std")]
+	#[cfg(feature = "unicode-normalization")]
 	pub fn parse_in<'a, S: Into<Cow<'a, str>>>(
 		language: Language,
 		s: S,
@@ -517,7 +518,7 @@ impl Mnemonic {
 	}
 
 	/// Parse a mnemonic and detect the language from the enabled languages.
-	#[cfg(feature = "std")]
+	#[cfg(feature = "unicode-normalization")]
 	pub fn parse<'a, S: Into<Cow<'a, str>>>(s: S) -> Result<Mnemonic, Error> {
 		let mut cow = s.into();
 		Mnemonic::normalize_utf8_cow(&mut cow);
@@ -547,7 +548,7 @@ impl Mnemonic {
 	}
 
 	/// Convert to seed bytes.
-	#[cfg(feature = "std")]
+	#[cfg(feature = "unicode-normalization")]
 	pub fn to_seed<'a, P: Into<Cow<'a, str>>>(&self, passphrase: P) -> [u8; 64] {
 		let normalized_passphrase = {
 			let mut cow = passphrase.into();
@@ -596,7 +597,7 @@ impl Mnemonic {
 	}
 
 	/// Convert the mnemonic back to the entropy used to generate it.
-	#[cfg(feature = "std")]
+	#[cfg(feature = "alloc")]
 	pub fn to_entropy(&self) -> Vec<u8> {
 		let (arr, len) = self.to_entropy_array();
 		arr[0..len].to_vec()
@@ -648,11 +649,11 @@ impl str::FromStr for Mnemonic {
 	type Err = Error;
 
 	fn from_str(s: &str) -> Result<Mnemonic, Error> {
-		#[cfg(feature = "std")]
+		#[cfg(feature = "unicode-normalization")]
 		{
 			Mnemonic::parse(s)
 		}
-		#[cfg(not(feature = "std"))]
+		#[cfg(not(feature = "unicode-normalization"))]
 		{
 			Mnemonic::parse_normalized(s)
 		}
@@ -871,7 +872,7 @@ mod tests {
 				mnemonic_str
 			);
 
-			#[cfg(feature = "std")]
+			#[cfg(feature = "unicode-normalization")]
 			{
 				assert_eq!(&mnemonic.to_string(), mnemonic_str, "failed vector: {}", mnemonic_str);
 				assert_eq!(


### PR DESCRIPTION
This PR introduces the `alloc` feature.

The `alloc` is intended to use in no-std environments which are allowed to use `alloc`. New feature enables:
-  the `unicode-normalization`, and all related methods (`parse_in`,`normalize_utf8_cow`,`parse`,`to_seed`)
-  `fn to_entropy()` method as `Vec` is available in `alloc`,

Some formatting sneaked in, too.

Fix for #55.