### PR TITLE
fix some important std unit tests that were not running due to typo

### DIFF
--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -8,9 +8,9 @@ macro_rules! serde_string_impl {
 			where
 				D: $crate::serde::de::Deserializer<'de>,
 			{
+				use alloc::string::String;
 				use core::fmt::{self, Formatter};
 				use core::str::FromStr;
-				use alloc::string::String;
 
 				struct Visitor;
 				impl<'de> $crate::serde::de::Visitor<'de> for Visitor {

--- a/src/language/chinese_simplified.rs
+++ b/src/language/chinese_simplified.rs
@@ -1,3 +1,4 @@
+#[rustfmt::skip]
 pub const WORDS: [&str; 2048] = [
 	"的",
 	"一",

--- a/src/language/chinese_traditional.rs
+++ b/src/language/chinese_traditional.rs
@@ -1,3 +1,4 @@
+#[rustfmt::skip]
 pub const WORDS: [&str; 2048] = [
 	"的",
 	"一",

--- a/src/language/czech.rs
+++ b/src/language/czech.rs
@@ -1,3 +1,4 @@
+#[rustfmt::skip]
 pub const WORDS: [&str; 2048] = [
 	"abdikace",
 	"abeceda",

--- a/src/language/english.rs
+++ b/src/language/english.rs
@@ -1,3 +1,4 @@
+#[rustfmt::skip]
 pub const WORDS: [&str; 2048] = [
 	"abandon",
 	"ability",

--- a/src/language/french.rs
+++ b/src/language/french.rs
@@ -1,3 +1,4 @@
+#[rustfmt::skip]
 pub const WORDS: [&str; 2048] = [
 	"abaisser",
 	"abandon",

--- a/src/language/italian.rs
+++ b/src/language/italian.rs
@@ -1,3 +1,4 @@
+#[rustfmt::skip]
 pub const WORDS: [&str; 2048] = [
 	"abaco",
 	"abbaglio",

--- a/src/language/japanese.rs
+++ b/src/language/japanese.rs
@@ -1,3 +1,4 @@
+#[rustfmt::skip]
 pub const WORDS: [&str; 2048] = [
 	"あいこくしん",
 	"あいさつ",

--- a/src/language/korean.rs
+++ b/src/language/korean.rs
@@ -1,3 +1,4 @@
+#[rustfmt::skip]
 pub const WORDS: [&str; 2048] = [
 	"가격",
 	"가끔",

--- a/src/language/portuguese.rs
+++ b/src/language/portuguese.rs
@@ -1,3 +1,4 @@
+#[rustfmt::skip]
 pub const WORDS: [&str; 2048] = [
 	"abacate",
 	"abaixo",

--- a/src/language/spanish.rs
+++ b/src/language/spanish.rs
@@ -1,3 +1,4 @@
+#[rustfmt::skip]
 pub const WORDS: [&str; 2048] = [
 	"ábaco",
 	"abdomen",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -842,7 +842,7 @@ mod tests {
 				mnemonic_str
 			);
 
-			#[cfg(features = "std")]
+			#[cfg(feature = "std")]
 			{
 				assert_eq!(&mnemonic.to_string(), mnemonic_str, "failed vector: {}", mnemonic_str);
 				assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,10 @@ extern crate bitcoin_hashes;
 #[cfg(feature = "std")]
 extern crate unicode_normalization;
 
-#[cfg(feature = "rand_core")]
-pub extern crate rand_core;
 #[cfg(feature = "rand")]
 pub extern crate crate_rand as rand;
+#[cfg(feature = "rand_core")]
+pub extern crate rand_core;
 #[cfg(feature = "serde")]
 pub extern crate serde;
 
@@ -542,12 +542,7 @@ impl Mnemonic {
 		const PBKDF2_BYTES: usize = 64;
 
 		let mut seed = [0u8; PBKDF2_BYTES];
-		pbkdf2::pbkdf2(
-			self.words(),
-			normalized_passphrase.as_bytes(),
-			PBKDF2_ROUNDS,
-			&mut seed,
-		);
+		pbkdf2::pbkdf2(self.words(), normalized_passphrase.as_bytes(), PBKDF2_ROUNDS, &mut seed);
 		seed
 	}
 

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -4,7 +4,8 @@ const SALT_PREFIX: &'static str = "mnemonic";
 
 /// Calculate the binary size of the mnemonic.
 fn mnemonic_byte_len<M>(mnemonic: M) -> usize
-	where M: Iterator<Item = &'static str> + Clone,
+where
+	M: Iterator<Item = &'static str> + Clone,
 {
 	let mut len = 0;
 	for (i, word) in mnemonic.enumerate() {
@@ -18,7 +19,8 @@ fn mnemonic_byte_len<M>(mnemonic: M) -> usize
 
 /// Wrote the mnemonic in binary form into the hash engine.
 fn mnemonic_write_into<M>(mnemonic: M, engine: &mut sha512::HashEngine)
-	where M: Iterator<Item = &'static str> + Clone,
+where
+	M: Iterator<Item = &'static str> + Clone,
 {
 	for (i, word) in mnemonic.enumerate() {
 		if i > 0 {
@@ -32,7 +34,8 @@ fn mnemonic_write_into<M>(mnemonic: M, engine: &mut sha512::HashEngine)
 /// We need a special method because we can't allocate a new byte
 /// vector for the entire serialized mnemonic.
 fn create_hmac_engine<M>(mnemonic: M) -> hmac::HmacEngine<sha512::Hash>
-	where M: Iterator<Item = &'static str> + Clone,
+where
+	M: Iterator<Item = &'static str> + Clone,
 {
 	// Inner code is borrowed from the bitcoin_hashes::hmac::HmacEngine::new method.
 	let mut ipad = [0x36u8; 128];
@@ -97,7 +100,8 @@ fn xor(res: &mut [u8], salt: &[u8]) {
 
 /// PBKDF2-HMAC-SHA512 implementation using bitcoin_hashes.
 pub(crate) fn pbkdf2<M>(mnemonic: M, unprefixed_salt: &[u8], c: usize, res: &mut [u8])
-	where M: Iterator<Item = &'static str> + Clone,
+where
+	M: Iterator<Item = &'static str> + Clone,
 {
 	let prf = create_hmac_engine(mnemonic);
 


### PR DESCRIPTION
`#[cfg(features = "std")]` is invalid and always disabled the whole block.

rustfmt re-applied and explictly excluded the language slices - it seems the project generally uses rustfmt there is a .rustfmt.toml file).