### PR TITLE
Use rand crate re-exports when available

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,13 @@ pub extern crate serde;
 
 use core::{fmt, str};
 
+/// We support a wide range of dependency versions for `rand` and `rand_core` and not
+/// all versions play nicely together. These re-exports fix that.
+#[cfg(all(feature = "rand", feature = "rand_core"))]
+use rand::{CryptoRng, RngCore};
+#[cfg(all(not(feature = "rand"), feature = "rand_core"))]
+use rand_core::{CryptoRng, RngCore};
+
 #[cfg(feature = "std")]
 use std::borrow::Cow;
 #[cfg(feature = "std")]
@@ -262,7 +269,7 @@ impl Mnemonic {
 		word_count: usize,
 	) -> Result<Mnemonic, Error>
 	where
-		R: rand_core::RngCore + rand_core::CryptoRng,
+		R: RngCore + CryptoRng,
 	{
 		if is_invalid_word_count(word_count) {
 			return Err(Error::BadWordCount(word_count));
@@ -270,7 +277,7 @@ impl Mnemonic {
 
 		let entropy_bytes = (word_count / 3) * 4;
 		let mut entropy = [0u8; (MAX_NB_WORDS / 3) * 4];
-		rand_core::RngCore::fill_bytes(rng, &mut entropy[0..entropy_bytes]);
+		RngCore::fill_bytes(rng, &mut entropy[0..entropy_bytes]);
 		Mnemonic::from_entropy_in(language, &entropy[0..entropy_bytes])
 	}
 


### PR DESCRIPTION
Re-exports from `rand` crate shall be used. Otherwise trait bounds in `Mnemonic::generate_in_with` for `rand::thread_rng` object can get unsatisfied if crate deps get ouf of sync.

This commit is fixing following errors:
```
error[E0277]: the trait bound `ThreadRng: rand_core::RngCore` is not satisfied
   --> /home/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bip39-2.0.0/src/lib.rs:292:30
    |
292 |         Mnemonic::generate_in_with(&mut rand::thread_rng(), language, word_count)
    |         -------------------------- ^^^^^^^^^^^^^^^^^^^^^^^ the trait `rand_core::RngCore` is not implemented for `ThreadRng`
    |         |
    |         required by a bound introduced by this call
    |::
    = help: the following other types implement trait `rand_core::RngCore`:
...
note: required by a bound in `Mnemonic::generate_in_with`
   --> /home/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bip39-2.0.0/src/lib.rs:266:6
    |
260 |     pub fn generate_in_with<R>(
    |            ---------------- required by a bound in this associated function
...
266 |         R: rand_core::RngCore + rand_core::CryptoRng,
    |            ^^^^^^^^^^^^^^^^^^ required by this bound in `Mnemonic::generate_in_with`

```

```
error[E0277]: the trait bound `ThreadRng: rand_core::CryptoRng` is not satisfied
   --> /home/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bip39-2.0.0/src/lib.rs:292:30
    |
292 |         Mnemonic::generate_in_with(&mut rand::thread_rng(), language, word_count)
    |         -------------------------- ^^^^^^^^^^^^^^^^^^^^^^^ the trait `rand_core::CryptoRng` is not implemented for `ThreadRng`
    |         |
    |         required by a bound introduced by this call
    |
    = help: the following other types implement trait `rand_core::CryptoRng`:
...
note: required by a bound in `Mnemonic::generate_in_with`
   --> /home/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bip39-2.0.0/src/lib.rs:266:27
    |
260 |     pub fn generate_in_with<R>(
    |            ---------------- required by a bound in this associated function
...
266 |         R: rand_core::RngCore + rand_core::CryptoRng,
    |                                 ^^^^^^^^^^^^^^^^^^^^ required by this bound in `Mnemonic::generate_in_with`

```