### PR TITLE
compilation fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub extern crate rand_core;
 pub extern crate serde;
 
 #[cfg(feature = "alloc")]
-use alloc::{borrow::Cow, string::ToString, vec::Vec};
+use alloc::borrow::Cow;
 use core::{fmt, str};
 
 /// We support a wide range of dependency versions for `rand` and `rand_core` and not


### PR DESCRIPTION
fixing following error (introduced in #57):
```
error: the item `ToString` is imported redundantly
  --> src/lib.rs:48:26
error: the item `Vec` is imported redundantly
  --> src/lib.rs:48:44

error: could not compile `bip39` (lib) due to 2 previous errors
```