### PR TITLE
Remove unnecessary imports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub extern crate rand_core;
 pub extern crate serde;
 
 #[cfg(feature = "alloc")]
-use alloc::{borrow::Cow, string::ToString, vec::Vec};
+use alloc::borrow::Cow;
 use core::{fmt, str};
 
 /// We support a wide range of dependency versions for `rand` and `rand_core` and not


### PR DESCRIPTION
`Vec` and `ToString` are part of stdlib prelude now, no need to import them explicitly.

Clears two rustc `unused_imports` errors.