### PR TITLE
Remove path dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,6 @@ bitcoin_hashes = { version = ">=0.12, <=0.13", default-features = false }
 unicode-normalization = { version = "=0.1.22", default-features = false, optional = true }
 
 [dev-dependencies]
-# Enabling the "rand" feature by default to run the benches
-bip39 = { path = ".", features = ["rand"] }
 bitcoin_hashes = ">=0.12,<0.14" # enable default features for test
 
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -59,6 +59,7 @@ fn from_entropy(b: &mut Bencher) {
 	});
 }
 
+#[cfg(feature = "rand")]
 #[bench]
 fn new_mnemonic(b: &mut Bencher) {
 	b.iter(|| {


### PR DESCRIPTION
Currently we are enabling "rand" using a path dependency in the dev-dependencies because of the benches. This is reducing coverage in CI because "std" is always enabled.

Feature gate the bench that requires "rand" and remove the path dependency.