### PR TITLE
cargo: bump `unicode-normalization` to `0.1.23`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ zeroize = { version = "1.5", features = ["zeroize_derive"], optional = true }
 
 # Unexported dependnecies
 bitcoin_hashes = { version = ">=0.12, <=0.13", default-features = false }
-unicode-normalization = { version = "=0.1.22", default-features = false, optional = true }
+unicode-normalization = { version = "=0.1.23", default-features = false, optional = true }
 
 [dev-dependencies]
 # Enabling the "rand" feature by default to run the benches


### PR DESCRIPTION
released 4 months ago

Closes #73.