### PR TITLE
Enable `bitcoin_hashes v0.14.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,13 @@ serde = { version = "1.0", default-features = false, features = [ "alloc" ], opt
 zeroize = { version = "1.5", features = ["zeroize_derive"], optional = true }
 
 # Unexported dependnecies
-bitcoin_hashes = { version = ">=0.12, <=0.13", default-features = false }
+bitcoin_hashes = { version = ">=0.12,<0.15", default-features = false }
 unicode-normalization = { version = "0.1.22", default-features = false, optional = true }
 
 [dev-dependencies]
 # Enabling the "rand" feature by default to run the benches
 bip39 = { path = ".", features = ["rand"] }
-bitcoin_hashes = ">=0.12,<0.14" # enable default features for test
+bitcoin_hashes = ">=0.12,<0.15" # enable default features for test
 
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The `bitcoin_hashes` range dependency effects the MSRV as follows
 
 - `bitcoin_hashes v0.12`: MSRV v1.41.1
 - `bitcoin_hashes v0.13`: MSRV v1.48.0
+- `bitcoin_hashes v0.14`: MSRV v1.56.0
 
 When using older version of Rust, you might have to pin the versions of several crates, for an up-to-date list refer to [`contrib/test.sh`](contrib/test.sh):
 


### PR DESCRIPTION
Hardware devices like the smallest binary possible, currently if one builds with latest `rust-bitcoin` and `rust-bip39` they get two versions of `bitcoin_hashes` in the dependency graph because we don't support the latest `bitcoin_hashes`.

Note using the latest version causes the MSRV to increase to `Rust v0.56.1`.

