### PR TITLE
chore: allow using `bitcoin_hashes` v0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,13 @@ serde = { version = "1.0", default-features = false, features = [ "alloc" ], opt
 zeroize = { version = "1.5", features = ["zeroize_derive"], optional = true }
 
 # Unexported dependnecies
-bitcoin_hashes = { version = ">=0.12, <=0.13", default-features = false }
+bitcoin_hashes = { version = ">=0.12, <=0.14", default-features = false }
 unicode-normalization = { version = "=0.1.22", default-features = false, optional = true }
 
 [dev-dependencies]
 # Enabling the "rand" feature by default to run the benches
 bip39 = { path = ".", features = ["rand"] }
-bitcoin_hashes = ">=0.12,<0.14" # enable default features for test
+bitcoin_hashes = ">=0.12,<=0.14" # enable default features for test
 
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
It appears to be API-compatible for the purposes of this crate, so there should be no harm in allowing it and will help others projects deduplicate dependencies.

I also tested 0.15 and that lead to errors.

What are your thoughts on a 0.2.2 release if we can land this? Should I just include a version bump+changelog entry in the PR as a separate commit?