### PR TITLE
Make unicode normalization optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,19 @@ edition = "2018"
 
 [features]
 default = [ "std" ]
-std = [ "alloc", "serde/std", "unicode-normalization/std" ]
+std = [ "alloc", "serde/std", "unicode-normalization?/std" ]
 rand = [ "crate_rand", "rand_core" ]
-alloc = [ "unicode-normalization" ]
+alloc = []
+unicode-normalization = [ "dep:unicode-normalization", "alloc" ] 
 
 # Note: English is the standard for bip39 so always included
-chinese-simplified = []
-chinese-traditional = []
+chinese-simplified = [ "unicode-normalization" ]
+chinese-traditional = [ "unicode-normalization" ]
 czech = []
 french = []
 italian = []
-japanese = []
-korean = []
+japanese = [ "unicode-normalization" ]
+korean = [ "unicode-normalization" ]
 portuguese = []
 spanish = []
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub extern crate rand_core;
 #[cfg(feature = "serde")]
 pub extern crate serde;
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "unicode-normalization")]
 use alloc::borrow::Cow;
 use core::{fmt, str};
 


### PR DESCRIPTION
Potential solution for https://github.com/rust-bitcoin/rust-bip39/pull/28#issuecomment-2873760890

With default features this is the dependency tree now:
```
bip39 v2.1.0 (/home/user/projects/elsirion/rust-bip39)
├── bitcoin_hashes v0.13.0
│   ├── bitcoin-internals v0.2.0
│   └── hex-conservative v0.1.2
├── rand v0.8.5
│   ├── libc v0.2.162
│   ├── rand_chacha v0.3.1
│   │   ├── ppv-lite86 v0.2.20
│   │   │   └── zerocopy v0.7.35
│   │   │       ├── byteorder v1.5.0
│   │   │       └── zerocopy-derive v0.7.35 (proc-macro)
│   │   │           ├── proc-macro2 v1.0.89
│   │   │           │   └── unicode-ident v1.0.13
│   │   │           ├── quote v1.0.37
│   │   │           │   └── proc-macro2 v1.0.89 (*)
│   │   │           └── syn v2.0.87
│   │   │               ├── proc-macro2 v1.0.89 (*)
│   │   │               ├── quote v1.0.37 (*)
│   │   │               └── unicode-ident v1.0.13
│   │   └── rand_core v0.6.4
│   │       └── getrandom v0.2.15
│   │           ├── cfg-if v1.0.0
│   │           └── libc v0.2.162
│   └── rand_core v0.6.4 (*)
├── rand_core v0.6.4 (*)
└── serde v1.0.214
```