### PR TITLE
`doc_auto_cfg` -> `doc_cfg`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 #![deny(unused_imports)]
 #![deny(missing_docs)]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(any(test, feature = "std"))]
 pub extern crate core;


### PR DESCRIPTION
Unfortunately, 2.2.1 has a broken build on docs.rs due to this.