### PR TITLE
Cut v2.2.2 to fix `docs.rs` breakage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,3 +98,14 @@ jobs:
         run: cargo install cross --locked
       - name: run cross test
         run: cross test --target s390x-unknown-linux-gnu
+
+  Docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/install@cargo-docs-rs
+      - run: cargo docs-rs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
 
+# v2.2.2 - Dec. 4, 2025
+- Fix `docs.rs` builds (#101)
+
 # v2.2.1 - Dec. 3, 2025
 - Bump `bitcoin_hashes` dependency to v0.14.0 (#76)
 - Redact `Debug` output of `Mnemonic` (#93)

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -17,7 +17,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bip39"
-version = "2.2.0"
+version = "2.2.2"
 dependencies = [
  "bip39",
  "bitcoin_hashes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip39"
-version = "2.2.1"
+version = "2.2.2"
 authors = ["Steven Roose <steven@stevenroose.org>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-bip39/"


### PR DESCRIPTION
Unfortunately, `docs.rs` builds on v2.2.1 turned out to be broken, so we cut another patch release to fix documentation builds.

Also, to avoid running into any future documentation breakage, we add a CI job that checks our docs builds as expected.
