### PR TITLE
Prepare v2.3.0 minor release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+# v2.3.0 - Aug. 20, 2026
+- Add `WordCount` for mnemonic generation (#98)
+- Use the operating system RNG for mnemonic generation and require rand v0.7 or newer (#105)
+- Add complete multilingual prefix lookup and deprecate the incomplete slice-based API (#104)
+- Preserve ambiguous mnemonic languages through entropy recovery and serde round trips (#108)
+
 # v2.2.2 - Dec. 4, 2025
 - Fix `docs.rs` builds (#101)
 

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "bip39"
-version = "2.2.2"
+version = "2.3.0"
 dependencies = [
  "bip39",
  "bitcoin_hashes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bip39"
-version = "2.2.2"
+version = "2.3.0"
 authors = ["Steven Roose <steven@stevenroose.org>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-bip39/"


### PR DESCRIPTION
Bump crate metadata and document the user-facing changes since v2.2.2. Include the pending ambiguous-language round-trip fix so the release notes are ready when it lands.

Note this already includes #108, so we should land that first before merging this.